### PR TITLE
Fix README formatting

### DIFF
--- a/crewai_tools/tools/directory_read_tool/README.md
+++ b/crewai_tools/tools/directory_read_tool/README.md
@@ -1,4 +1,3 @@
-```markdown
 # DirectoryReadTool
 
 ## Description
@@ -35,6 +34,5 @@ The DirectoryReadTool requires minimal configuration for use. The essential argu
 - `directory`: A mandatory argument that specifies the path to the directory whose contents you wish to list. It accepts both absolute and relative paths, guiding the tool to the desired directory for content listing.
 
 The DirectoryReadTool provides a user-friendly and efficient way to list directory contents, making it an invaluable tool for managing and inspecting directory structures.
-```
 
 This revised documentation for the DirectoryReadTool maintains the structure and content requirements as outlined, with adjustments made for clarity, consistency, and adherence to the high-quality standards exemplified in the provided documentation example.


### PR DESCRIPTION
## Summary
- remove leading ```markdown and trailing ``` from the DirectoryReadTool docs

## Testing
- `uv run pytest` *(fails: could not fetch pygithub)*
- `uv run pyright` *(fails: could not fetch cryptography)*

## Summary by Sourcery

Documentation:
- Remove markdown code fences from DirectoryReadTool documentation